### PR TITLE
k8s-upgrader fixes

### DIFF
--- a/config/kubernetes/nodes.toml
+++ b/config/kubernetes/nodes.toml
@@ -3,6 +3,7 @@ microk8s_version = "1.28/stable"
 [[singularity_node]]
 name = "singularity001"
 ip_address = "192.168.60.11"
+ignore_firmware = true
 [[singularity_node]]
 name = "singularity002"
 ip_address = "192.168.60.12"


### PR DESCRIPTION
- ignore firmware udpdates on the nodes that don't support it
- remove version checks and cycle through all nodes unconditionally (version checks aren't robust enough to skip nodes yet)